### PR TITLE
fix(cve): CVE-2026-21721 - Dashboard Permissions Scope Bypass

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -372,13 +372,14 @@ func (hs *HTTPServer) registerRoutes() {
 			dashboardRoute.Get("/tags", hs.GetDashboardTags)
 
 			dashboardRoute.Group("/id/:dashboardId", func(dashIdRoute routing.RouteRegister) {
+				dashIDScope := dashboards.ScopeDashboardsProvider.GetResourceScope(ac.Parameter(":dashboardId"))
 				dashIdRoute.Get("/versions", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsWrite)), routing.Wrap(hs.GetDashboardVersions))
 				dashIdRoute.Get("/versions/:id", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsWrite)), routing.Wrap(hs.GetDashboardVersion))
 				dashIdRoute.Post("/restore", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsWrite)), routing.Wrap(hs.RestoreDashboardVersion))
 
 				dashIdRoute.Group("/permissions", func(dashboardPermissionRoute routing.RouteRegister) {
-					dashboardPermissionRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsPermissionsRead)), routing.Wrap(hs.GetDashboardPermissionList))
-					dashboardPermissionRoute.Post("/", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsPermissionsWrite)), routing.Wrap(hs.UpdateDashboardPermissions))
+					dashboardPermissionRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsPermissionsRead, dashIDScope)), routing.Wrap(hs.GetDashboardPermissionList))
+					dashboardPermissionRoute.Post("/", authorize(reqSignedIn, ac.EvalPermission(ac.ActionDashboardsPermissionsWrite, dashIDScope)), routing.Wrap(hs.UpdateDashboardPermissions))
 				})
 			})
 		})

--- a/pkg/services/dashboards/accesscontrol.go
+++ b/pkg/services/dashboards/accesscontrol.go
@@ -27,6 +27,9 @@ const (
 var (
 	ScopeFoldersAll      = ac.GetResourceAllScope(ScopeFoldersRoot)
 	ScopeFoldersProvider = ac.NewScopeProvider(ScopeFoldersRoot)
+
+	ScopeDashboardsAll      = ac.GetResourceAllScope(ScopeDashboardsRoot)
+	ScopeDashboardsProvider = ac.NewScopeProvider(ScopeDashboardsRoot)
 )
 
 // NewNameScopeResolver provides an AttributeScopeResolver that is able to convert a scope prefixed with "folders:name:" into an uid based scope.


### PR DESCRIPTION
## Summary
Fixes **CVE-2026-21721** — Dashboard Permissions Scope Bypass that enables cross-dashboard privilege escalation.

### CVE Details
- **CVE ID**: CVE-2026-21721
- **Component**: Grafana API (dashboard permissions)
- **Impact**: Missing scope check on dashboard permissions endpoints allows users to read/modify permissions on dashboards they shouldn't have access to
- **Upstream fix**: grafana/grafana#116894

### Changes
1. **pkg/services/dashboards/accesscontrol.go**: Added `ScopeDashboardsProvider` for resource-scoped dashboard authorization
2. **pkg/api/api.go**: Added dashboard ID scope parameter to `EvalPermission` calls on `/id/:dashboardId/permissions` routes

### How it works
Before this fix, the dashboard permissions endpoints (`GET/POST /api/dashboards/id/:dashboardId/permissions`) only checked if the user had the `dashboards.permissions:read` or `dashboards.permissions:write` action globally, without scoping to the specific dashboard. This allowed a user with these permissions on any dashboard to read/modify permissions on ALL dashboards.

After this fix, the permission check includes the specific dashboard's resource scope (`dashboards:id:<dashboardId>`), ensuring users can only manage permissions on dashboards they're authorized for.

### Test Results
⚠️ Build verified — full test suite requires CI

### Breaking Changes
None — this is a strictly additive security check

### Risk Assessment
| Factor | Assessment |
|--------|-----------|
| Change scope | Low — 2 files, adds scope parameter to existing auth checks |
| Breaking risk | Low — only restricts previously over-permissive behavior |
| Upstream validated | Yes — ported from grafana/grafana#116894 |

Resolves: ACM-29141

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->