### PR TITLE
fix(cve): CVE-2025-9288 - sha.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,8 @@
     "@storybook/react/webpack": "5.70.0",
     "node-fetch": "2.6.7",
     "@types/slate": "0.47.9",
-    "slate-dev-environment@^0.2.2": "patch:slate-dev-environment@npm:0.2.5#.yarn/patches/slate-dev-environment-npm-0.2.5-9aeb7da7b5.patch"
+    "slate-dev-environment@^0.2.2": "patch:slate-dev-environment@npm:0.2.5#.yarn/patches/slate-dev-environment-npm-0.2.5-9aeb7da7b5.patch",
+    "sha.js": "2.4.12"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -33096,8 +33096,8 @@ __metadata:
   linkType: hard
 
 "sha.js@npm:^2.4.0, sha.js@npm:^2.4.8":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
+  version: 2.4.12
+  resolution: "sha.js@npm:2.4.12"
   dependencies:
     inherits: ^2.0.1
     safe-buffer: ^5.0.1


### PR DESCRIPTION
## Summary
Fixes **CVE-2025-9288** by adding a yarn resolution to force sha.js v2.4.12.

### CVE Details
- **CVE ID**: CVE-2025-9288
- **Package**: sha.js (npm, transitive dependency)
- **Severity**: Moderate
- **Impact**: Improper input validation allows input data manipulation
- **Vulnerable versions**: through 2.4.11
- **Fixed version**: 2.4.12

### Changes
- Added `"sha.js": "2.4.12"` to `resolutions` in `package.json`
- Updated `yarn.lock` to reference sha.js 2.4.12

### Risk Assessment
Low — patch version bump for transitive dependency

Resolves: ACM-23518

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->