### PR TITLE
Security: Fix CVE-2026-41604, CVE-2026-41603, CVE-2026-41636 (apache/thrift)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -332,7 +332,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/apache/thrift v0.22.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,8 @@ github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0I
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
-github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=


### PR DESCRIPTION
## CVE Details

| Field | Value |
|-------|-------|
| CVE IDs | CVE-2026-41604, CVE-2026-41603, CVE-2026-41636 |
| Package | github.com/apache/thrift |
| Severity | Important |
| CVSS Scores | 8.2, 8.2, 7.5 |
| Vulnerable versions | < 0.23.0 |
| Fixed version | v0.23.0 |
| Jira issues | ACM-33480, ACM-33470, ACM-33456 |

## Fix Summary

Updated `github.com/apache/thrift` to v0.23.0, addressing three vulnerabilities:
- **CVE-2026-41604**: Out-of-bounds Read vulnerability
- **CVE-2026-41603**: Security Bypass via Improper Certificate Hostname Validation
- **CVE-2026-41636**: Node.js skip() recursion (DoS)

## Verification

- [x] Go build verified
- [x] `go mod tidy` clean
- [ ] Manual code review
- [ ] Integration tests

## Risk Assessment

**Low** — indirect dependency bump, minor version.

<!-- cve-fixer-workflow -->